### PR TITLE
Declare const parameters as const

### DIFF
--- a/include/lsl_c.h
+++ b/include/lsl_c.h
@@ -257,7 +257,7 @@ extern LIBLSL_C_API int lsl_resolve_all(lsl_streaminfo *buffer, unsigned buffer_
 * @return The number of results written into the buffer (never more than the provided # of slots) 
 *         or a negative number if an error has occurred (values corresponding to lsl_error_code_t).
 */
-extern LIBLSL_C_API int lsl_resolve_byprop(lsl_streaminfo *buffer, unsigned buffer_elements, char *prop, char *value, int minimum, double timeout);
+extern LIBLSL_C_API int lsl_resolve_byprop(lsl_streaminfo *buffer, unsigned buffer_elements, const char *prop, const char *value, int minimum, double timeout);
 
 /**
 * Resolve all streams that match a given predicate.
@@ -277,7 +277,7 @@ extern LIBLSL_C_API int lsl_resolve_byprop(lsl_streaminfo *buffer, unsigned buff
 * @return The number of results written into the buffer (never more than the provided # of slots) 
 *         or a negative number if an error has occurred (values corresponding to lsl_error_code_t).
 */
-extern LIBLSL_C_API int lsl_resolve_bypred(lsl_streaminfo *buffer, unsigned buffer_elements, char *pred, int minimum, double timeout);
+extern LIBLSL_C_API int lsl_resolve_bypred(lsl_streaminfo *buffer, unsigned buffer_elements, const char *pred, int minimum, double timeout);
 
 /** 
 * Deallocate a string that has been transferred to the application.
@@ -310,7 +310,7 @@ extern LIBLSL_C_API void lsl_destroy_string(char *s);
 *                  May in some cases also be constructed from device settings.
 * @return A newly created streaminfo handle or NULL in the event that an error occurred.
 */
-extern LIBLSL_C_API lsl_streaminfo lsl_create_streaminfo(char *name, char *type, int channel_count, double nominal_srate, lsl_channel_format_t channel_format, char *source_id);
+extern LIBLSL_C_API lsl_streaminfo lsl_create_streaminfo(const char *name, const char *type, int channel_count, double nominal_srate, lsl_channel_format_t channel_format, const char *source_id);
 
 /**
 * Destroy a previously created streaminfo object.
@@ -329,7 +329,7 @@ extern LIBLSL_C_API lsl_streaminfo lsl_copy_streaminfo(lsl_streaminfo info);
 * Multiple streams with the same name can coexist, though potentially at the cost of ambiguity (for the recording app or experimenter).
 * @return A library-owned pointer to the string value. Modification is not permitted.
 */
-extern LIBLSL_C_API char *lsl_get_name(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_name(lsl_streaminfo info);
 
 /**
 * Content type of the stream.
@@ -339,7 +339,7 @@ extern LIBLSL_C_API char *lsl_get_name(lsl_streaminfo info);
 * Content types usually follow those pre-defined in https://github.com/sccn/xdf/wiki/Meta-Data (or web search for: XDF meta-data).
 * @return A library-owned pointer to the string value. Modification is not permitted.
 */
-extern LIBLSL_C_API char *lsl_get_type(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_type(lsl_streaminfo info);
 
 /**
 * Number of channels of the stream.
@@ -371,7 +371,7 @@ extern LIBLSL_C_API lsl_channel_format_t lsl_get_channel_format(lsl_streaminfo i
 * endpoints (such as the recording program) can re-acquire a stream automatically once it is back online.
 * @return A library-owned pointer to the string value. Modification is not permitted.
 */
-extern LIBLSL_C_API char *lsl_get_source_id(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_source_id(lsl_streaminfo info);
 
 /**
 * Protocol version used to deliver the stream.
@@ -391,7 +391,7 @@ extern LIBLSL_C_API double lsl_get_created_at(lsl_streaminfo info);
 * across multiple instantiations of the same outlet (e.g., after a re-start).
 * @return A library-owned pointer to the string value. Modification is not permitted.
 */
-extern LIBLSL_C_API char *lsl_get_uid(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_uid(lsl_streaminfo info);
 
 /**
 * Session ID for the given stream.
@@ -401,12 +401,12 @@ extern LIBLSL_C_API char *lsl_get_uid(lsl_streaminfo info);
 * (assigned via a configuration file by the experimenter, see Network Connectivity on the LSL wiki).
 * @return A library-owned pointer to the string value. Modification is not permitted.
 */
-extern LIBLSL_C_API char *lsl_get_session_id(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_session_id(lsl_streaminfo info);
 
 /**
 * Hostname of the providing machine (once bound to an outlet). Modification is not permitted.
 */
-extern LIBLSL_C_API char *lsl_get_hostname(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_hostname(lsl_streaminfo info);
 
 /**
 * Extended description of the stream.
@@ -431,7 +431,7 @@ extern LIBLSL_C_API lsl_xml_ptr lsl_get_desc(lsl_streaminfo info);
 * @return A pointer to a copy of the XML text or NULL in the event that an error occurred.
 *         Note: It is the user's responsibility to deallocate this string when it is no longer needed.
 */
-extern LIBLSL_C_API char *lsl_get_xml(lsl_streaminfo info);
+extern LIBLSL_C_API const char *lsl_get_xml(lsl_streaminfo info);
 
 /// Number of bytes occupied by a channel (0 for string-typed channels).
 extern LIBLSL_C_API int lsl_get_channel_bytes(lsl_streaminfo info);
@@ -440,7 +440,7 @@ extern LIBLSL_C_API int lsl_get_channel_bytes(lsl_streaminfo info);
 extern LIBLSL_C_API int lsl_get_sample_bytes(lsl_streaminfo info);
 
 /// Create a streaminfo object from an XML representation
-extern LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(char *xml);
+extern LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(const char *xml);
 
 
 
@@ -480,33 +480,33 @@ extern LIBLSL_C_API void lsl_destroy_outlet(lsl_outlet out);
 *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
 * @return Error code of the operation or lsl_no_error if successful (usually attributed to the wrong data type).
 */
-extern LIBLSL_C_API int lsl_push_sample_f(lsl_outlet out, float *data);
-extern LIBLSL_C_API int lsl_push_sample_ft(lsl_outlet out, float *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_ftp(lsl_outlet out, float *data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_d(lsl_outlet out, double *data);
-extern LIBLSL_C_API int lsl_push_sample_dt(lsl_outlet out, double *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_dtp(lsl_outlet out, double *data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_l(lsl_outlet out, long *data);
-extern LIBLSL_C_API int lsl_push_sample_lt(lsl_outlet out, long *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_ltp(lsl_outlet out, long *data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_i(lsl_outlet out, int *data);
-extern LIBLSL_C_API int lsl_push_sample_it(lsl_outlet out, int *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_itp(lsl_outlet out, int *data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_s(lsl_outlet out, short *data);
-extern LIBLSL_C_API int lsl_push_sample_st(lsl_outlet out, short *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_stp(lsl_outlet out, short *data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_c(lsl_outlet out, char *data);
-extern LIBLSL_C_API int lsl_push_sample_ct(lsl_outlet out, char *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_ctp(lsl_outlet out, char *data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_str(lsl_outlet out, char **data);
-extern LIBLSL_C_API int lsl_push_sample_strt(lsl_outlet out, char **data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_strtp(lsl_outlet out, char **data, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_buf(lsl_outlet out, char **data, unsigned *lengths);
-extern LIBLSL_C_API int lsl_push_sample_buft(lsl_outlet out, char **data, unsigned *lengths, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_buftp(lsl_outlet out, char **data, unsigned *lengths, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_sample_v(lsl_outlet out, void *data);
-extern LIBLSL_C_API int lsl_push_sample_vt(lsl_outlet out, void *data, double timestamp);
-extern LIBLSL_C_API int lsl_push_sample_vtp(lsl_outlet out, void *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_f(lsl_outlet out, const float *data);
+extern LIBLSL_C_API int lsl_push_sample_ft(lsl_outlet out, const float *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_ftp(lsl_outlet out, const float *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_d(lsl_outlet out, const double *data);
+extern LIBLSL_C_API int lsl_push_sample_dt(lsl_outlet out, const double *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_dtp(lsl_outlet out, const double *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_l(lsl_outlet out, const long *data);
+extern LIBLSL_C_API int lsl_push_sample_lt(lsl_outlet out, const long *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_ltp(lsl_outlet out, const long *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_i(lsl_outlet out, const int *data);
+extern LIBLSL_C_API int lsl_push_sample_it(lsl_outlet out, const int *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_itp(lsl_outlet out, const int *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_s(lsl_outlet out, const short *data);
+extern LIBLSL_C_API int lsl_push_sample_st(lsl_outlet out, const short *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_stp(lsl_outlet out, const short *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_c(lsl_outlet out, const char *data);
+extern LIBLSL_C_API int lsl_push_sample_ct(lsl_outlet out, const char *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_ctp(lsl_outlet out, const char *data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_str(lsl_outlet out, const char **data);
+extern LIBLSL_C_API int lsl_push_sample_strt(lsl_outlet out, const char **data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_strtp(lsl_outlet out, const char **data, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_buf(lsl_outlet out, const char **data, const unsigned *lengths);
+extern LIBLSL_C_API int lsl_push_sample_buft(lsl_outlet out, const char **data, const unsigned *lengths, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_buftp(lsl_outlet out, const char **data, const unsigned *lengths, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_sample_v(lsl_outlet out, const void *data);
+extern LIBLSL_C_API int lsl_push_sample_vt(lsl_outlet out, const void *data, double timestamp);
+extern LIBLSL_C_API int lsl_push_sample_vtp(lsl_outlet out, const void *data, double timestamp, int pushthrough);
 
 
 /**
@@ -524,46 +524,46 @@ extern LIBLSL_C_API int lsl_push_sample_vtp(lsl_outlet out, void *data, double t
 *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
 * @return Error code of the operation (usually attributed to the wrong data type).
 */
-extern LIBLSL_C_API int lsl_push_chunk_f(lsl_outlet out, float *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_ft(lsl_outlet out, float *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_ftp(lsl_outlet out, float *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_ftn(lsl_outlet out, float *data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_ftnp(lsl_outlet out, float *data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_d(lsl_outlet out, double *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_dt(lsl_outlet out, double *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_dtp(lsl_outlet out, double *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_dtn(lsl_outlet out, double *data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_dtnp(lsl_outlet out, double *data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_l(lsl_outlet out, long *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_lt(lsl_outlet out, long *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_ltp(lsl_outlet out, long *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_ltn(lsl_outlet out, long *data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_ltnp(lsl_outlet out, long *data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_i(lsl_outlet out, int *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_it(lsl_outlet out, int *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_itp(lsl_outlet out, int *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_itn(lsl_outlet out, int *data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_itnp(lsl_outlet out, int *data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_s(lsl_outlet out, short *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_st(lsl_outlet out, short *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_stp(lsl_outlet out, short *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_stn(lsl_outlet out, short *data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_stnp(lsl_outlet out, short *data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_c(lsl_outlet out, char *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_ct(lsl_outlet out, char *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_ctp(lsl_outlet out, char *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_ctn(lsl_outlet out, char *data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_ctnp(lsl_outlet out, char *data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_str(lsl_outlet out, char **data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_strt(lsl_outlet out, char **data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_strtp(lsl_outlet out, char **data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_strtn(lsl_outlet out, char **data, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_strtnp(lsl_outlet out, char **data, unsigned long data_elements, double *timestamps, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_buf(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_buft(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_buftp(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_buftn(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_buftnp(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_f(lsl_outlet out, const float *data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_ft(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_ftp(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_ftn(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_ftnp(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_d(lsl_outlet out, const double *data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_dt(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_dtp(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_dtn(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_dtnp(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_l(lsl_outlet out, const long *data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_lt(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_ltp(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_ltn(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_ltnp(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_i(lsl_outlet out, const int *data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_it(lsl_outlet out, const int *data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_itp(lsl_outlet out, const int *data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_itn(lsl_outlet out, const int *data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_itnp(lsl_outlet out, const int *data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_s(lsl_outlet out, const short *data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_st(lsl_outlet out, const short *data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_stp(lsl_outlet out, const short *data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_stn(lsl_outlet out, const short *data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_stnp(lsl_outlet out, const short *data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_c(lsl_outlet out, const char *data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_ct(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_ctp(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_ctn(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_ctnp(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_str(lsl_outlet out, const char **data, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_strt(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_strtp(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_strtn(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_strtnp(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_buf(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements);
+extern LIBLSL_C_API int lsl_push_chunk_buft(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, double timestamp);
+extern LIBLSL_C_API int lsl_push_chunk_buftp(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, double timestamp, int pushthrough);
+extern LIBLSL_C_API int lsl_push_chunk_buftn(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, const double *timestamps);
+extern LIBLSL_C_API int lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, const double *timestamps, int pushthrough);
 
 
 /**
@@ -857,13 +857,13 @@ extern LIBLSL_C_API lsl_xml_ptr lsl_parent(lsl_xml_ptr e);
 /* === XML Tree Navigation by Name === */
 
 /** Get a child with a specified name. */
-extern LIBLSL_C_API lsl_xml_ptr lsl_child(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API lsl_xml_ptr lsl_child(lsl_xml_ptr e, const char *name);
 
 /** Get the next sibling with the specified name. */
-extern LIBLSL_C_API lsl_xml_ptr lsl_next_sibling_n(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API lsl_xml_ptr lsl_next_sibling_n(lsl_xml_ptr e, const char *name);
 
 /** Get the previous sibling with the specified name. */
-extern LIBLSL_C_API lsl_xml_ptr lsl_previous_sibling_n(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API lsl_xml_ptr lsl_previous_sibling_n(lsl_xml_ptr e, const char *name);
 
 
 /* === Content Queries === */
@@ -875,16 +875,16 @@ extern LIBLSL_C_API int lsl_empty(lsl_xml_ptr e);
 extern LIBLSL_C_API int  lsl_is_text(lsl_xml_ptr e);
 
 /** Name of the element. */
-extern LIBLSL_C_API char *lsl_name(lsl_xml_ptr e);
+extern LIBLSL_C_API const char *lsl_name(lsl_xml_ptr e);
 
 /** Value of the element. */
-extern LIBLSL_C_API char *lsl_value(lsl_xml_ptr e);
+extern LIBLSL_C_API const char *lsl_value(lsl_xml_ptr e);
 
 /** Get child value (value of the first child that is text). */
-extern LIBLSL_C_API char* lsl_child_value(lsl_xml_ptr e);
+extern LIBLSL_C_API const char* lsl_child_value(lsl_xml_ptr e);
 
 /** Get child value of a child with a specified name. */
-extern LIBLSL_C_API char* lsl_child_value_n(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API const char* lsl_child_value_n(lsl_xml_ptr e, const char *name);
 
 
 /* === Data Modification === */
@@ -892,35 +892,35 @@ extern LIBLSL_C_API char* lsl_child_value_n(lsl_xml_ptr e, char *name);
 /**
 * Append a child node with a given name, which has a (nameless) plain-text child with the given text value.
 */
-extern LIBLSL_C_API lsl_xml_ptr lsl_append_child_value(lsl_xml_ptr e, char *name, char *value);
+extern LIBLSL_C_API lsl_xml_ptr lsl_append_child_value(lsl_xml_ptr e, const char *name, const char *value);
 
 /**
 * Prepend a child node with a given name, which has a (nameless) plain-text child with the given text value.
 */
-extern LIBLSL_C_API lsl_xml_ptr lsl_prepend_child_value(lsl_xml_ptr e, char *name, char *value);
+extern LIBLSL_C_API lsl_xml_ptr lsl_prepend_child_value(lsl_xml_ptr e, const char *name, const char *value);
 
 /**
 * Set the text value of the (nameless) plain-text child of a named child node.
 */
-extern LIBLSL_C_API int lsl_set_child_value(lsl_xml_ptr e, char *name, char *value);
+extern LIBLSL_C_API int lsl_set_child_value(lsl_xml_ptr e, const char *name, const char *value);
 
 /**
 * Set the element's name.
 * @return 0 if the node is empty (or if out of memory).
 */
-extern LIBLSL_C_API int lsl_set_name(lsl_xml_ptr e, char *rhs);
+extern LIBLSL_C_API int lsl_set_name(lsl_xml_ptr e, const char *rhs);
 
 /**
 * Set the element's value.
 * @return 0 if the node is empty (or if out of memory).
 */
-extern LIBLSL_C_API int lsl_set_value(lsl_xml_ptr e, char *rhs);
+extern LIBLSL_C_API int lsl_set_value(lsl_xml_ptr e, const char *rhs);
 
 /** Append a child element with the specified name. */
-extern LIBLSL_C_API lsl_xml_ptr lsl_append_child(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API lsl_xml_ptr lsl_append_child(lsl_xml_ptr e, const char *name);
 
 /** Prepend a child element with the specified name. */
-extern LIBLSL_C_API lsl_xml_ptr lsl_prepend_child(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API lsl_xml_ptr lsl_prepend_child(lsl_xml_ptr e, const char *name);
 
 /** Append a copy of the specified element as a child. */
 extern LIBLSL_C_API lsl_xml_ptr lsl_append_copy(lsl_xml_ptr e, lsl_xml_ptr e2);
@@ -929,7 +929,7 @@ extern LIBLSL_C_API lsl_xml_ptr lsl_append_copy(lsl_xml_ptr e, lsl_xml_ptr e2);
 extern LIBLSL_C_API lsl_xml_ptr lsl_prepend_copy(lsl_xml_ptr e, lsl_xml_ptr e2);
 
 /** Remove a child element with the specified name. */
-extern LIBLSL_C_API void lsl_remove_child_n(lsl_xml_ptr e, char *name);
+extern LIBLSL_C_API void lsl_remove_child_n(lsl_xml_ptr e, const char *name);
 
 /** Remove a specified child element. */
 extern LIBLSL_C_API void lsl_remove_child(lsl_xml_ptr e, lsl_xml_ptr e2);
@@ -959,7 +959,7 @@ extern LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver(doubl
 *                     this is the time in seconds after which it is no longer reported by the resolver.
 *                     The recommended default value is 5.0.
 */
-extern LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(char *prop, char *value, double forget_after);
+extern LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(const char *prop, const char *value, double forget_after);
 
 /**
 * Construct a new continuous_resolver that resolves all streams that match a given XPath 1.0 predicate.
@@ -969,7 +969,7 @@ extern LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypro
 *                     this is the time in seconds after which it is no longer reported by the resolver.
 *                     The recommended default value is 5.0.
 */
-extern LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypred(char *pred, double forget_after);
+extern LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypred(const char *pred, double forget_after);
 
 /**
 * Obtain the set of currently present streams on the network (i.e. resolve result).

--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -307,7 +307,7 @@ namespace lsl {
         ~stream_info() { lsl_destroy_streaminfo(obj); }
 
 		/// Utility function to create a stream_info from an XML representation
-		static stream_info from_xml(const std::string &xml) { return stream_info(lsl_streaminfo_from_xml((char*)xml.c_str())); }
+		static stream_info from_xml(const std::string &xml) { return stream_info(lsl_streaminfo_from_xml(xml.c_str())); }
     private:
         mutable lsl_streaminfo obj;
     };

--- a/src/lsl_continuous_resolver_c.cpp
+++ b/src/lsl_continuous_resolver_c.cpp
@@ -3,7 +3,7 @@
 #include "common.h"
 #include <iostream>
 
-
+extern "C" {
 // === implementation of the continuous_resolver class ===
 
 using namespace lsl;
@@ -38,7 +38,7 @@ LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver(double forge
 *				      this is the time in seconds after which it is no longer reported by the resolver.
 *					  The recommended default value is 5.0.
 */
-LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(char *prop, char *value, double forget_after) {
+LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(const char *prop, const char *value, double forget_after) {
 	try {
 		// create a new resolver
 		resolver_impl *resolver = new resolver_impl();
@@ -60,7 +60,7 @@ LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(char 
 *				      this is the time in seconds after which it is no longer reported by the resolver.
 *					  The recommended default value is 5.0.
 */
-LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypred(char *pred, double forget_after) {
+LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypred(const char *pred, double forget_after) {
 	try {
 		// create a new resolver
 		resolver_impl *resolver = new resolver_impl();
@@ -109,4 +109,4 @@ LIBLSL_C_API void lsl_destroy_continuous_resolver(lsl_continuous_resolver res) {
 		std::cerr << "Unexpected during destruction of a continuous_resolver: " << e.what() << std::endl;
 	}
 }
-
+}

--- a/src/lsl_freefuncs_c.cpp
+++ b/src/lsl_freefuncs_c.cpp
@@ -10,7 +10,7 @@ using namespace lsl;
 using std::string;
 using std::vector;
 
-
+extern "C" {
 /**
 * Get the protocol version.
 */
@@ -92,7 +92,7 @@ LIBLSL_C_API int lsl_resolve_all(lsl_streaminfo *buffer, unsigned buffer_element
 * @return The number of results written into the buffer (never more than the provided # of slots) or a negative number if an
 *		  error has occurred (values corresponding to lsl_error_code_t).
 */
-LIBLSL_C_API int lsl_resolve_byprop(lsl_streaminfo *buffer, unsigned buffer_elements, char *prop, char *value, int minimum, double timeout) {
+LIBLSL_C_API int lsl_resolve_byprop(lsl_streaminfo *buffer, unsigned buffer_elements, const char *prop, const char *value, int minimum, double timeout) {
 	try {
 		// create a new resolver
 		resolver_impl resolver;
@@ -126,7 +126,7 @@ LIBLSL_C_API int lsl_resolve_byprop(lsl_streaminfo *buffer, unsigned buffer_elem
 * @return The number of results written into the buffer (never more than the provided # of slots) or a negative number if an
 *		  error has occurred (values corresponding to lsl_error_code_t).
 */
-LIBLSL_C_API int lsl_resolve_bypred(lsl_streaminfo *buffer, unsigned buffer_elements, char *pred, int minimum, double timeout) {
+LIBLSL_C_API int lsl_resolve_bypred(lsl_streaminfo *buffer, unsigned buffer_elements, const char *pred, int minimum, double timeout) {
 	try {
 		// create a new resolver
 		resolver_impl resolver;
@@ -154,4 +154,5 @@ LIBLSL_C_API int lsl_resolve_bypred(lsl_streaminfo *buffer, unsigned buffer_elem
 LIBLSL_C_API void lsl_destroy_string(char *s) {
 	if (s)
 		free(s);
+}
 }

--- a/src/lsl_inlet_c.cpp
+++ b/src/lsl_inlet_c.cpp
@@ -1,8 +1,7 @@
 #include "../include/lsl_c.h"
 #include "stream_inlet_impl.h"
 
-
-
+extern "C" {
 // === implementation of the stream_inlet class ===
 
 using namespace lsl;
@@ -233,7 +232,7 @@ LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int buffer_
 		double result = ((stream_inlet_impl*)in)->pull_sample(tmp,timeout);
         if (buffer_elements < (int)tmp.size())
             throw std::range_error("The provided buffer has fewer elements than the stream's number of channels.");
-		// allocate memory and copy over into buffer
+		// allocate memory and copy over into buffer#include "../include/lsl_c.h"
 		for (unsigned k=0;k<tmp.size();k++) {
 			buffer[k] = (char*)malloc(tmp[k].size()+1);
 			if (buffer[k] == NULL) {
@@ -509,4 +508,5 @@ LIBLSL_C_API int lsl_smoothing_halftime(lsl_inlet in, float value) {
 	catch(std::exception &) {
 		return lsl_internal_error;
 	}
+}
 }

--- a/src/lsl_outlet_c.cpp
+++ b/src/lsl_outlet_c.cpp
@@ -3,6 +3,7 @@
 #include "stream_outlet_impl.h"
 
 
+extern "C" {
 // === implementation of the lsl_outlet functions of the C API ===
 
 using namespace lsl;
@@ -27,79 +28,79 @@ LIBLSL_C_API void lsl_destroy_outlet(lsl_outlet out) {
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_f(lsl_outlet out, float *data) { 
+LIBLSL_C_API int lsl_push_sample_f(lsl_outlet out, const float *data) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
-LIBLSL_C_API int lsl_push_sample_ft(lsl_outlet out, float *data, double timestamp) {
+LIBLSL_C_API int lsl_push_sample_ft(lsl_outlet out, const float *data, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
-LIBLSL_C_API int lsl_push_sample_ftp(lsl_outlet out, float *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_ftp(lsl_outlet out, const float *data, double timestamp, int pushthrough) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int lsl_push_sample_d(lsl_outlet out, double *data) { 
+LIBLSL_C_API int lsl_push_sample_d(lsl_outlet out, const double *data) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
-LIBLSL_C_API int lsl_push_sample_dt(lsl_outlet out, double *data, double timestamp) { 
+LIBLSL_C_API int lsl_push_sample_dt(lsl_outlet out, const double *data, double timestamp) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
-LIBLSL_C_API int lsl_push_sample_dtp(lsl_outlet out, double *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_dtp(lsl_outlet out, const double *data, double timestamp, int pushthrough) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int lsl_push_sample_l(lsl_outlet out, long *data) { 
+LIBLSL_C_API int lsl_push_sample_l(lsl_outlet out, const long *data) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
-LIBLSL_C_API int lsl_push_sample_lt(lsl_outlet out, long *data, double timestamp) { 
+LIBLSL_C_API int lsl_push_sample_lt(lsl_outlet out, const long *data, double timestamp) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
-LIBLSL_C_API int lsl_push_sample_ltp(lsl_outlet out, long *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_ltp(lsl_outlet out, const long *data, double timestamp, int pushthrough) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int lsl_push_sample_i(lsl_outlet out, int *data) { 
+LIBLSL_C_API int lsl_push_sample_i(lsl_outlet out, const int *data) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
-LIBLSL_C_API int lsl_push_sample_it(lsl_outlet out, int *data, double timestamp) { 
+LIBLSL_C_API int lsl_push_sample_it(lsl_outlet out, const int *data, double timestamp) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
-LIBLSL_C_API int lsl_push_sample_itp(lsl_outlet out, int *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_itp(lsl_outlet out, const int *data, double timestamp, int pushthrough) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int lsl_push_sample_s(lsl_outlet out, short *data) { 
+LIBLSL_C_API int lsl_push_sample_s(lsl_outlet out, const short *data) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
-LIBLSL_C_API int lsl_push_sample_st(lsl_outlet out, short *data, double timestamp) { 
+LIBLSL_C_API int lsl_push_sample_st(lsl_outlet out, const short *data, double timestamp) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
-LIBLSL_C_API int lsl_push_sample_stp(lsl_outlet out, short *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_stp(lsl_outlet out, const short *data, double timestamp, int pushthrough) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int lsl_push_sample_c(lsl_outlet out, char *data) { 
+LIBLSL_C_API int lsl_push_sample_c(lsl_outlet out, const char *data) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
-LIBLSL_C_API int lsl_push_sample_ct(lsl_outlet out, char *data, double timestamp) { 
+LIBLSL_C_API int lsl_push_sample_ct(lsl_outlet out, const char *data, double timestamp) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
-LIBLSL_C_API int lsl_push_sample_ctp(lsl_outlet out, char *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_ctp(lsl_outlet out, const char *data, double timestamp, int pushthrough) { 
 	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int lsl_push_sample_v(lsl_outlet out, void *data) { 
+LIBLSL_C_API int lsl_push_sample_v(lsl_outlet out, const void *data) { 
 	try {
 		((stream_outlet_impl*)out)->push_numeric_raw(data); 
 		return lsl_no_error;
@@ -118,7 +119,7 @@ LIBLSL_C_API int lsl_push_sample_v(lsl_outlet out, void *data) {
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_vt(lsl_outlet out, void *data, double timestamp) { 
+LIBLSL_C_API int lsl_push_sample_vt(lsl_outlet out, const void *data, double timestamp) { 
 	try {
 		((stream_outlet_impl*)out)->push_numeric_raw(data,timestamp); 
 		return lsl_no_error;
@@ -137,7 +138,7 @@ LIBLSL_C_API int lsl_push_sample_vt(lsl_outlet out, void *data, double timestamp
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_vtp(lsl_outlet out, void *data, double timestamp, int pushthrough) { 
+LIBLSL_C_API int lsl_push_sample_vtp(lsl_outlet out, const void *data, double timestamp, int pushthrough) { 
 	try {
 		((stream_outlet_impl*)out)->push_numeric_raw(data,timestamp,pushthrough!=0); 
 		return lsl_no_error;
@@ -156,7 +157,7 @@ LIBLSL_C_API int lsl_push_sample_vtp(lsl_outlet out, void *data, double timestam
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_str(lsl_outlet out, char **data) {
+LIBLSL_C_API int lsl_push_sample_str(lsl_outlet out, const char **data) {
 	try {
 		stream_outlet_impl* outimpl = (stream_outlet_impl*)out;
 		std::vector<std::string> tmp;
@@ -179,7 +180,7 @@ LIBLSL_C_API int lsl_push_sample_str(lsl_outlet out, char **data) {
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_strt(lsl_outlet out, char **data, double timestamp) {
+LIBLSL_C_API int lsl_push_sample_strt(lsl_outlet out, const char **data, double timestamp) {
 	try {
 		stream_outlet_impl* outimpl = (stream_outlet_impl*)out;
 		std::vector<std::string> tmp;
@@ -202,7 +203,7 @@ LIBLSL_C_API int lsl_push_sample_strt(lsl_outlet out, char **data, double timest
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_strtp(lsl_outlet out, char **data, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_sample_strtp(lsl_outlet out, const char **data, double timestamp, int pushthrough) {
 	try {
 		stream_outlet_impl* outimpl = (stream_outlet_impl*)out;
 		std::vector<std::string> tmp;
@@ -225,7 +226,7 @@ LIBLSL_C_API int lsl_push_sample_strtp(lsl_outlet out, char **data, double times
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_buf(lsl_outlet out, char **data, unsigned *lengths) {
+LIBLSL_C_API int lsl_push_sample_buf(lsl_outlet out, const char **data, const unsigned *lengths) {
 	try {
 		stream_outlet_impl* outimpl = (stream_outlet_impl*)out;
 		std::vector<std::string> tmp;
@@ -248,7 +249,7 @@ LIBLSL_C_API int lsl_push_sample_buf(lsl_outlet out, char **data, unsigned *leng
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_buft(lsl_outlet out, char **data, unsigned *lengths, double timestamp) {
+LIBLSL_C_API int lsl_push_sample_buft(lsl_outlet out, const char **data, const unsigned *lengths, double timestamp) {
 	try {
 		stream_outlet_impl* outimpl = (stream_outlet_impl*)out;
 		std::vector<std::string> tmp;
@@ -271,7 +272,7 @@ LIBLSL_C_API int lsl_push_sample_buft(lsl_outlet out, char **data, unsigned *len
 	}
 }
 
-LIBLSL_C_API int lsl_push_sample_buftp(lsl_outlet out, char **data, unsigned *lengths, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_sample_buftp(lsl_outlet out, const char **data, const unsigned *lengths, double timestamp, int pushthrough) {
 	try {
 		stream_outlet_impl* outimpl = (stream_outlet_impl*)out;
 		std::vector<std::string> tmp;
@@ -294,7 +295,7 @@ LIBLSL_C_API int lsl_push_sample_buftp(lsl_outlet out, char **data, unsigned *le
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_f(lsl_outlet out, float *data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_f(lsl_outlet out, const float *data, unsigned long data_elements) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements); 
 		return lsl_no_error;
@@ -313,7 +314,7 @@ LIBLSL_C_API int lsl_push_chunk_f(lsl_outlet out, float *data, unsigned long dat
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_d(lsl_outlet out, double *data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_d(lsl_outlet out, const double *data, unsigned long data_elements) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements); 
 		return lsl_no_error;
@@ -332,7 +333,7 @@ LIBLSL_C_API int lsl_push_chunk_d(lsl_outlet out, double *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_l(lsl_outlet out, long *data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_l(lsl_outlet out, const long *data, unsigned long data_elements) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements); 
 		return lsl_no_error;
@@ -351,7 +352,7 @@ LIBLSL_C_API int lsl_push_chunk_l(lsl_outlet out, long *data, unsigned long data
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_i(lsl_outlet out, int *data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_i(lsl_outlet out, const int *data, unsigned long data_elements) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements); 
 		return lsl_no_error;
@@ -370,7 +371,7 @@ LIBLSL_C_API int lsl_push_chunk_i(lsl_outlet out, int *data, unsigned long data_
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_s(lsl_outlet out, short *data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_s(lsl_outlet out, const short *data, unsigned long data_elements) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements); 
 		return lsl_no_error;
@@ -389,7 +390,7 @@ LIBLSL_C_API int lsl_push_chunk_s(lsl_outlet out, short *data, unsigned long dat
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_c(lsl_outlet out, char *data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_c(lsl_outlet out, const char *data, unsigned long data_elements) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements); 
 		return lsl_no_error;
@@ -408,7 +409,7 @@ LIBLSL_C_API int lsl_push_chunk_c(lsl_outlet out, char *data, unsigned long data
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ft(lsl_outlet out, float *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_ft(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp); 
 		return lsl_no_error;
@@ -427,7 +428,7 @@ LIBLSL_C_API int lsl_push_chunk_ft(lsl_outlet out, float *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_dt(lsl_outlet out, double *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_dt(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp); 
 		return lsl_no_error;
@@ -446,7 +447,7 @@ LIBLSL_C_API int lsl_push_chunk_dt(lsl_outlet out, double *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_lt(lsl_outlet out, long *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_lt(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp); 
 		return lsl_no_error;
@@ -465,7 +466,7 @@ LIBLSL_C_API int lsl_push_chunk_lt(lsl_outlet out, long *data, unsigned long dat
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_it(lsl_outlet out, int *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_it(lsl_outlet out, const int *data, unsigned long data_elements, double timestamp) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp); 
 		return lsl_no_error;
@@ -484,7 +485,7 @@ LIBLSL_C_API int lsl_push_chunk_it(lsl_outlet out, int *data, unsigned long data
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_st(lsl_outlet out, short *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_st(lsl_outlet out, const short *data, unsigned long data_elements, double timestamp) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp); 
 		return lsl_no_error;
@@ -503,7 +504,7 @@ LIBLSL_C_API int lsl_push_chunk_st(lsl_outlet out, short *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ct(lsl_outlet out, char *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_ct(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp); 
 		return lsl_no_error;
@@ -522,7 +523,7 @@ LIBLSL_C_API int lsl_push_chunk_ct(lsl_outlet out, char *data, unsigned long dat
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ftp(lsl_outlet out, float *data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_ftp(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp,pushthrough); 
 		return lsl_no_error;
@@ -541,7 +542,7 @@ LIBLSL_C_API int lsl_push_chunk_ftp(lsl_outlet out, float *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_dtp(lsl_outlet out, double *data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_dtp(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp,pushthrough); 
 		return lsl_no_error;
@@ -560,7 +561,7 @@ LIBLSL_C_API int lsl_push_chunk_dtp(lsl_outlet out, double *data, unsigned long 
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ltp(lsl_outlet out, long *data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_ltp(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp,pushthrough); 
 		return lsl_no_error;
@@ -579,7 +580,7 @@ LIBLSL_C_API int lsl_push_chunk_ltp(lsl_outlet out, long *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_itp(lsl_outlet out, int *data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_itp(lsl_outlet out, const int *data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp,pushthrough); 
 		return lsl_no_error;
@@ -598,7 +599,7 @@ LIBLSL_C_API int lsl_push_chunk_itp(lsl_outlet out, int *data, unsigned long dat
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_stp(lsl_outlet out, short *data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_stp(lsl_outlet out, const short *data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp,pushthrough); 
 		return lsl_no_error;
@@ -617,7 +618,7 @@ LIBLSL_C_API int lsl_push_chunk_stp(lsl_outlet out, short *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ctp(lsl_outlet out, char *data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_ctp(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,data_elements,timestamp,pushthrough); 
 		return lsl_no_error;
@@ -636,7 +637,7 @@ LIBLSL_C_API int lsl_push_chunk_ctp(lsl_outlet out, char *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ftn(lsl_outlet out, float *data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_ftn(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements); 
 		return lsl_no_error;
@@ -655,7 +656,7 @@ LIBLSL_C_API int lsl_push_chunk_ftn(lsl_outlet out, float *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_dtn(lsl_outlet out, double *data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_dtn(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements); 
 		return lsl_no_error;
@@ -674,7 +675,7 @@ LIBLSL_C_API int lsl_push_chunk_dtn(lsl_outlet out, double *data, unsigned long 
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ltn(lsl_outlet out, long *data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_ltn(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements); 
 		return lsl_no_error;
@@ -693,7 +694,7 @@ LIBLSL_C_API int lsl_push_chunk_ltn(lsl_outlet out, long *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_itn(lsl_outlet out, int *data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_itn(lsl_outlet out, const int *data, unsigned long data_elements, const double *timestamps) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements); 
 		return lsl_no_error;
@@ -712,7 +713,7 @@ LIBLSL_C_API int lsl_push_chunk_itn(lsl_outlet out, int *data, unsigned long dat
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_stn(lsl_outlet out, short *data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_stn(lsl_outlet out, const short *data, unsigned long data_elements, const double *timestamps) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements); 
 		return lsl_no_error;
@@ -731,7 +732,7 @@ LIBLSL_C_API int lsl_push_chunk_stn(lsl_outlet out, short *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ctn(lsl_outlet out, char *data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_ctn(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements); 
 		return lsl_no_error;
@@ -750,7 +751,7 @@ LIBLSL_C_API int lsl_push_chunk_ctn(lsl_outlet out, char *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ftnp(lsl_outlet out, float *data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_ftnp(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements,pushthrough); 
 		return lsl_no_error;
@@ -769,7 +770,7 @@ LIBLSL_C_API int lsl_push_chunk_ftnp(lsl_outlet out, float *data, unsigned long 
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_dtnp(lsl_outlet out, double *data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_dtnp(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements,pushthrough); 
 		return lsl_no_error;
@@ -788,7 +789,7 @@ LIBLSL_C_API int lsl_push_chunk_dtnp(lsl_outlet out, double *data, unsigned long
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ltnp(lsl_outlet out, long *data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_ltnp(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements,pushthrough); 
 		return lsl_no_error;
@@ -807,7 +808,7 @@ LIBLSL_C_API int lsl_push_chunk_ltnp(lsl_outlet out, long *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_itnp(lsl_outlet out, int *data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_itnp(lsl_outlet out, const int *data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements,pushthrough); 
 		return lsl_no_error;
@@ -826,7 +827,7 @@ LIBLSL_C_API int lsl_push_chunk_itnp(lsl_outlet out, int *data, unsigned long da
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_stnp(lsl_outlet out, short *data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_stnp(lsl_outlet out, const short *data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements,pushthrough); 
 		return lsl_no_error;
@@ -845,7 +846,7 @@ LIBLSL_C_API int lsl_push_chunk_stnp(lsl_outlet out, short *data, unsigned long 
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_ctnp(lsl_outlet out, char *data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_ctnp(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		((stream_outlet_impl*)out)->push_chunk_multiplexed(data,timestamps,data_elements,pushthrough); 
 		return lsl_no_error;
@@ -864,7 +865,7 @@ LIBLSL_C_API int lsl_push_chunk_ctnp(lsl_outlet out, char *data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_str(lsl_outlet out, char **data, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_str(lsl_outlet out, const char **data, unsigned long data_elements) {
 	try {
 		std::vector<std::string> tmp;
 		for (unsigned long k=0;k<data_elements;k++)
@@ -887,7 +888,7 @@ LIBLSL_C_API int lsl_push_chunk_str(lsl_outlet out, char **data, unsigned long d
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_strt(lsl_outlet out, char **data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_strt(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp) {
 	try {
 		std::vector<std::string> tmp;
 		for (unsigned long k=0;k<data_elements;k++)
@@ -910,7 +911,7 @@ LIBLSL_C_API int lsl_push_chunk_strt(lsl_outlet out, char **data, unsigned long 
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_strtp(lsl_outlet out, char **data, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_strtp(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		std::vector<std::string> tmp;
 		for (unsigned long k=0;k<data_elements;k++)
@@ -933,7 +934,7 @@ LIBLSL_C_API int lsl_push_chunk_strtp(lsl_outlet out, char **data, unsigned long
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_strtn(lsl_outlet out, char **data, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_strtn(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps) {
 	try {
 		if (data_elements) {
 			std::vector<std::string> tmp;
@@ -957,7 +958,7 @@ LIBLSL_C_API int lsl_push_chunk_strtn(lsl_outlet out, char **data, unsigned long
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_strtnp(lsl_outlet out, char **data, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_strtnp(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		if (data_elements) {
 			std::vector<std::string> tmp;
@@ -981,7 +982,7 @@ LIBLSL_C_API int lsl_push_chunk_strtnp(lsl_outlet out, char **data, unsigned lon
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_buf(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements) {
+LIBLSL_C_API int lsl_push_chunk_buf(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements) {
 	try {
 		std::vector<std::string> tmp;
 		for (unsigned long k=0;k<data_elements;k++)
@@ -1004,7 +1005,7 @@ LIBLSL_C_API int lsl_push_chunk_buf(lsl_outlet out, char **data, unsigned *lengt
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_buft(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int lsl_push_chunk_buft(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, double timestamp) {
 	try {
 		std::vector<std::string> tmp;
 		for (unsigned long k=0;k<data_elements;k++)
@@ -1027,7 +1028,7 @@ LIBLSL_C_API int lsl_push_chunk_buft(lsl_outlet out, char **data, unsigned *leng
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_buftp(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double timestamp, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_buftp(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, double timestamp, int pushthrough) {
 	try {
 		std::vector<std::string> tmp;
 		for (unsigned long k=0;k<data_elements;k++)
@@ -1050,7 +1051,7 @@ LIBLSL_C_API int lsl_push_chunk_buftp(lsl_outlet out, char **data, unsigned *len
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_buftn(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double *timestamps) {
+LIBLSL_C_API int lsl_push_chunk_buftn(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, const double *timestamps) {
 	try {
 		if (data_elements) {
 			std::vector<std::string> tmp;
@@ -1074,7 +1075,7 @@ LIBLSL_C_API int lsl_push_chunk_buftn(lsl_outlet out, char **data, unsigned *len
 	}
 }
 
-LIBLSL_C_API int lsl_push_chunk_buftnp(lsl_outlet out, char **data, unsigned *lengths, unsigned long data_elements, double *timestamps, int pushthrough) {
+LIBLSL_C_API int lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const unsigned *lengths, unsigned long data_elements, const double *timestamps, int pushthrough) {
 	try {
 		if (data_elements) {
 			std::vector<std::string> tmp;
@@ -1128,3 +1129,4 @@ LIBLSL_C_API lsl_streaminfo lsl_get_info(lsl_outlet out) {
 	}
 }
 
+}

--- a/src/lsl_streaminfo_c.cpp
+++ b/src/lsl_streaminfo_c.cpp
@@ -1,18 +1,19 @@
-#include "../include/lsl_c.h"
 #include "stream_info_impl.h"
-#include <string.h>
+#include <string>
 #include <iostream>
 
+extern "C" {
+#include "../include/lsl_c.h"
 
 // === Implementation of the streaminfo-related functions of the C API ===
 
 using namespace lsl;
 
 // boilerplate wrapper code
-LIBLSL_C_API lsl_streaminfo lsl_create_streaminfo(char *name, char *type, int channel_count, double nominal_srate, lsl_channel_format_t channel_format, char *source_id) { 
+LIBLSL_C_API lsl_streaminfo lsl_create_streaminfo(const char *name, const char *type, int channel_count, double nominal_srate, lsl_channel_format_t channel_format, const char *source_id) {
 	try {
 		if (!source_id)
-			source_id = (char*)"";
+			source_id = "";
 		return (lsl_streaminfo)new stream_info_impl(name,type,channel_count,nominal_srate,(channel_format_t)channel_format,source_id); 
 	} catch(std::exception &e) {
 		std::cerr << "Unexpected error during streaminfo construction: " << e.what() << std::endl;
@@ -37,20 +38,20 @@ LIBLSL_C_API void lsl_destroy_streaminfo(lsl_streaminfo info) {
 	}
 }
 
-LIBLSL_C_API char *lsl_get_name(lsl_streaminfo info) { return const_cast<char*>(((stream_info_impl*)info)->name().c_str()); }
-LIBLSL_C_API char *lsl_get_type(lsl_streaminfo info) { return const_cast<char*>(((stream_info_impl*)info)->type().c_str()); }
+const char *lsl_get_type(lsl_streaminfo info) { return ((stream_info_impl*)info)->type().c_str(); }
+const char *lsl_get_name(lsl_streaminfo info) { return ((stream_info_impl*)info)->name().c_str(); }
 LIBLSL_C_API int lsl_get_channel_count(lsl_streaminfo info) { return ((stream_info_impl*)info)->channel_count(); }
 LIBLSL_C_API double lsl_get_nominal_srate(lsl_streaminfo info) { return ((stream_info_impl*)info)->nominal_srate(); }
 LIBLSL_C_API lsl_channel_format_t lsl_get_channel_format(lsl_streaminfo info) { return (lsl_channel_format_t)((stream_info_impl*)info)->channel_format(); }
-LIBLSL_C_API char *lsl_get_source_id(lsl_streaminfo info) { return const_cast<char*>(((stream_info_impl*)info)->source_id().c_str()); }
+const char *lsl_get_source_id(lsl_streaminfo info) { return ((stream_info_impl*)info)->source_id().c_str(); }
 LIBLSL_C_API int lsl_get_version(lsl_streaminfo info) { return ((stream_info_impl*)info)->version(); }
 LIBLSL_C_API double lsl_get_created_at(lsl_streaminfo info) { return ((stream_info_impl*)info)->created_at(); }
-LIBLSL_C_API char *lsl_get_uid(lsl_streaminfo info) { return const_cast<char*>(((stream_info_impl*)info)->uid().c_str()); }
-LIBLSL_C_API char *lsl_get_session_id(lsl_streaminfo info) { return const_cast<char*>(((stream_info_impl*)info)->session_id().c_str()); }
-LIBLSL_C_API char *lsl_get_hostname(lsl_streaminfo info) { return const_cast<char*>(((stream_info_impl*)info)->hostname().c_str()); }
+const char *lsl_get_uid(lsl_streaminfo info) { return ((stream_info_impl*)info)->uid().c_str(); }
+const char *lsl_get_session_id(lsl_streaminfo info) { return ((stream_info_impl*)info)->session_id().c_str(); }
+const char *lsl_get_hostname(lsl_streaminfo info) { return ((stream_info_impl*)info)->hostname().c_str(); }
 LIBLSL_C_API lsl_xml_ptr lsl_get_desc(lsl_streaminfo info) { return (lsl_xml_ptr)((stream_info_impl*)info)->desc().internal_object(); }
 
-LIBLSL_C_API char *lsl_get_xml(lsl_streaminfo info) {
+const char *lsl_get_xml(lsl_streaminfo info) {
 	try {
 		std::string tmp = ((stream_info_impl*)info)->to_fullinfo_message();
 		char *result = (char*)malloc(tmp.size()+1);
@@ -64,7 +65,7 @@ LIBLSL_C_API char *lsl_get_xml(lsl_streaminfo info) {
 LIBLSL_C_API int lsl_get_channel_bytes(lsl_streaminfo info) { return ((stream_info_impl*)info)->channel_bytes(); }
 LIBLSL_C_API int lsl_get_sample_bytes(lsl_streaminfo info) { return ((stream_info_impl*)info)->sample_bytes(); }
 
-LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(char *xml) {
+LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(const char *xml) {
 	try {
 		stream_info_impl *impl = new stream_info_impl(); 
 		impl->from_fullinfo_message(xml);
@@ -73,4 +74,6 @@ LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(char *xml) {
 		std::cerr << "Unexpected error during streaminfo construction: " << e.what() << std::endl;
 		return NULL;
 	}
+}
+
 }

--- a/src/lsl_xml_element_c.cpp
+++ b/src/lsl_xml_element_c.cpp
@@ -1,6 +1,7 @@
-#include "../include/lsl_c.h"
 #include "pugixml/pugixml.hpp"
 
+extern "C" {
+#include "../include/lsl_c.h"
 
 // === implementation of the lsl_xml_ptr functions of lsl_c.h ===
 
@@ -11,37 +12,38 @@ LIBLSL_C_API lsl_xml_ptr lsl_last_child(lsl_xml_ptr e) { return (lsl_xml_ptr)xml
 LIBLSL_C_API lsl_xml_ptr lsl_next_sibling(lsl_xml_ptr e) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).next_sibling().internal_object(); }
 LIBLSL_C_API lsl_xml_ptr lsl_previous_sibling(lsl_xml_ptr e) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).previous_sibling().internal_object(); }
 LIBLSL_C_API lsl_xml_ptr lsl_parent(lsl_xml_ptr e) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).parent().internal_object(); }
-LIBLSL_C_API lsl_xml_ptr lsl_child(lsl_xml_ptr e, char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).child(name).internal_object(); }
-LIBLSL_C_API lsl_xml_ptr lsl_next_sibling_n(lsl_xml_ptr e, char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).next_sibling(name).internal_object(); }
-LIBLSL_C_API lsl_xml_ptr lsl_previous_sibling_n(lsl_xml_ptr e, char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).previous_sibling(name).internal_object(); }
+LIBLSL_C_API lsl_xml_ptr lsl_child(lsl_xml_ptr e, const char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).child(name).internal_object(); }
+LIBLSL_C_API lsl_xml_ptr lsl_next_sibling_n(lsl_xml_ptr e, const char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).next_sibling(name).internal_object(); }
+LIBLSL_C_API lsl_xml_ptr lsl_previous_sibling_n(lsl_xml_ptr e, const char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).previous_sibling(name).internal_object(); }
 
 LIBLSL_C_API int lsl_empty(lsl_xml_ptr e) { return xml_node((xml_node_struct*)e).empty(); }
 LIBLSL_C_API int  lsl_is_text(lsl_xml_ptr e) { return xml_node((xml_node_struct*)e).type() != node_element; }
-LIBLSL_C_API char *lsl_name(lsl_xml_ptr e) { return const_cast<char*>(xml_node((xml_node_struct*)e).name()); }
-LIBLSL_C_API char *lsl_value(lsl_xml_ptr e) { return const_cast<char*>(xml_node((xml_node_struct*)e).value()); }
-LIBLSL_C_API char *lsl_child_value(lsl_xml_ptr e) { return const_cast<char*>(xml_node((xml_node_struct*)e).child_value()); }
-LIBLSL_C_API char *lsl_child_value_n(lsl_xml_ptr e, char *name) { return const_cast<char*>(xml_node((xml_node_struct*)e).child_value(name)); }
+LIBLSL_C_API const char *lsl_name(lsl_xml_ptr e) { return xml_node((xml_node_struct*)e).name(); }
+LIBLSL_C_API const char *lsl_value(lsl_xml_ptr e) { return xml_node((xml_node_struct*)e).value(); }
+LIBLSL_C_API const char *lsl_child_value(lsl_xml_ptr e) { return xml_node((xml_node_struct*)e).child_value(); }
+LIBLSL_C_API const char *lsl_child_value_n(lsl_xml_ptr e, const char *name) { return const_cast<char*>(xml_node((xml_node_struct*)e).child_value(name)); }
 
-LIBLSL_C_API int lsl_set_name(lsl_xml_ptr e, char *rhs) { return xml_node((xml_node_struct*)e).set_name(rhs); }
-LIBLSL_C_API int lsl_set_value(lsl_xml_ptr e, char *rhs) { return xml_node((xml_node_struct*)e).set_value(rhs); }
-LIBLSL_C_API lsl_xml_ptr lsl_append_child(lsl_xml_ptr e, char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).append_child(name).internal_object(); }
-LIBLSL_C_API lsl_xml_ptr lsl_prepend_child(lsl_xml_ptr e, char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).prepend_child(name).internal_object(); }
+LIBLSL_C_API int lsl_set_name(lsl_xml_ptr e, const char *rhs) { return xml_node((xml_node_struct*)e).set_name(rhs); }
+LIBLSL_C_API int lsl_set_value(lsl_xml_ptr e, const char *rhs) { return xml_node((xml_node_struct*)e).set_value(rhs); }
+LIBLSL_C_API lsl_xml_ptr lsl_append_child(lsl_xml_ptr e, const char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).append_child(name).internal_object(); }
+LIBLSL_C_API lsl_xml_ptr lsl_prepend_child(lsl_xml_ptr e, const char *name) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).prepend_child(name).internal_object(); }
 LIBLSL_C_API lsl_xml_ptr lsl_append_copy(lsl_xml_ptr e, lsl_xml_ptr e2) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).append_copy(xml_node((xml_node_struct*)e2)).internal_object(); }
 LIBLSL_C_API lsl_xml_ptr lsl_prepend_copy(lsl_xml_ptr e, lsl_xml_ptr e2) { return (lsl_xml_ptr)xml_node((xml_node_struct*)e).prepend_copy(xml_node((xml_node_struct*)e2)).internal_object(); }
-LIBLSL_C_API void lsl_remove_child_n(lsl_xml_ptr e, char *name) { xml_node((xml_node_struct*)e).remove_child(name); }
+LIBLSL_C_API void lsl_remove_child_n(lsl_xml_ptr e, const char *name) { xml_node((xml_node_struct*)e).remove_child(name); }
 LIBLSL_C_API void lsl_remove_child(lsl_xml_ptr e, lsl_xml_ptr e2) { xml_node((xml_node_struct*)e).remove_child(xml_node((xml_node_struct*)e2)); }
 
-LIBLSL_C_API int lsl_set_child_value(lsl_xml_ptr e, char *name, char *value) { return xml_node((xml_node_struct*)e).child(name).first_child().set_value(value); }
+LIBLSL_C_API int lsl_set_child_value(lsl_xml_ptr e, const char *name, const char *value) { return xml_node((xml_node_struct*)e).child(name).first_child().set_value(value); }
 
-LIBLSL_C_API lsl_xml_ptr lsl_append_child_value(lsl_xml_ptr e, char *name, char *value) {
+LIBLSL_C_API lsl_xml_ptr lsl_append_child_value(lsl_xml_ptr e, const char *name, const char *value) {
 	xml_node result = xml_node((xml_node_struct*)e).append_child(name);
 	result.append_child(node_pcdata).set_value(value);
 	return (lsl_xml_ptr)e;
 }
 
-LIBLSL_C_API lsl_xml_ptr lsl_prepend_child_value(lsl_xml_ptr e, char *name, char *value) {
+LIBLSL_C_API lsl_xml_ptr lsl_prepend_child_value(lsl_xml_ptr e, const char *name, const char *value) {
 	xml_node result = xml_node((xml_node_struct*)e).prepend_child(name);
 	result.append_child(node_pcdata).set_value(value);
 	return (lsl_xml_ptr)e;
 }
 
+}

--- a/src/sample.h
+++ b/src/sample.h
@@ -176,7 +176,7 @@ namespace lsl {
 		// === untyped accessors ===
 
 		/// Assign numeric data to the sample.
-		sample &assign_untyped(void *newdata) { 
+		sample &assign_untyped(const void *newdata) {
 			if (format_ != cf_string)
 				memcpy(&data_,newdata,format_sizes[format_]*num_channels_);
 			else
@@ -197,12 +197,12 @@ namespace lsl {
 
 		/// Helper function to save raw binary data to a stream buffer.
 		static void save_raw(std::streambuf &sb, const void *address, std::size_t count) {
-			if ((std::size_t)sb.sputn((char*)address,(std::streamsize)count) != count)
+			if ((std::size_t)sb.sputn((const char*)address,(std::streamsize)count) != count)
 				throw std::runtime_error("Output stream error.");
 		}
 
 		/// Helper function to load raw binary data from a stream buffer.
-		static void load_raw(std::streambuf &sb, const void *address, std::size_t count) {
+		static void load_raw(std::streambuf &sb, void *address, std::size_t count) {
 			if ((std::size_t)sb.sgetn((char*)address,(std::streamsize)count) != count)
 				throw std::runtime_error("Input stream error.");
 		}
@@ -246,7 +246,6 @@ namespace lsl {
 				default: throw std::runtime_error("Unsupported channel format for endian conversion.");
 			}
 		}
-
 		/// Serialize a sample into a portable archive (protocol 1.00).
 		template<class Archive> void save(Archive &ar, const unsigned int archive_version) const {
 			// write sample header

--- a/src/stream_outlet_impl.h
+++ b/src/stream_outlet_impl.h
@@ -102,7 +102,7 @@ namespace lsl {
 		* @param timestamp Optionally the capture time of the sample, in agreement with lsl_clock(); if omitted, the current time is assumed.
 		* @param pushthrough Whether to push the sample through to the receivers instead of buffering it into a chunk according to network speeds.
 		*/
-		void push_numeric_raw(void *data, double timestamp=0.0, bool pushthrough=true) { 
+		void push_numeric_raw(const void *data, double timestamp=0.0, bool pushthrough=true) {
 			if (lsl::api_config::get_instance()->force_default_timestamps())
 				timestamp = 0.0;
 			sample_p smp(sample_factory_->new_sample(timestamp == 0.0 ? lsl_clock() : timestamp, pushthrough));


### PR DESCRIPTION
This PR picks up 322b5244e1faf9d77b42c0f10944523db0d74dab by @cboulay (reverted because the const qualifiers caused the function names to be mangled and therefore not found when using C linkage) and adds the const qualifiers where needed (i.e. before most pointers to read-only buffers) and marks functions in `*_c.cpp` files as `extern "C"` so the names don't get mangled.